### PR TITLE
fix: not using random values as keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.8.1] - 2024-10-29
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-application-bucket-creation-helper/compare/0.8.0...0.8.1)
+
+- Fix `append_random_suffix` is now compatible with tagging buckets
+
 # [0.8.0] - 2024-08-09
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-application-bucket-creation-helper/compare/0.7.3...0.8.0)

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ locals {
   # Add the global tags to the buckets we want to tag and populate bucket location.
   list_of_buckets_to_be_tagged = [
     for bucket in var.buckets_list : {
-      bucket_name     = local.generated_bucket_names[bucket.name]
+      bucket_name     = bucket.name
       bucket_location = bucket.location != null ? bucket.location : local.default_region
       # If the bucket has no tags, we add the global tags, otherwise we use the bucket tags.
       tag_list = length(bucket.tag_list) > 0 ? bucket.tag_list : var.global_tags
@@ -129,7 +129,7 @@ data "google_tags_tag_value" "tag_values" {
 # Bind tags to buckets.
 resource "google_tags_location_tag_binding" "binding" {
   for_each   = local.map_of_buckets_to_be_tagged
-  parent     = "//storage.googleapis.com/projects/_/buckets/${each.value.bucket_name}"
+  parent     = "//storage.googleapis.com/projects/_/buckets/${local.generated_bucket_names[each.value.bucket_name]}"
   location   = each.value.bucket_location
   tag_value  = data.google_tags_tag_value.tag_values[each.value.tag_friendly_name].id
   depends_on = [google_storage_bucket.application, google_storage_bucket.disaster_recovery]


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect bucket name references in the tagging logic
- Updated `list_of_buckets_to_be_tagged` to use the original bucket name instead of the generated name
- Modified `google_tags_location_tag_binding` resource to use the correct generated bucket name in the `parent` attribute
- These changes ensure that the correct bucket names are used throughout the module, preventing potential issues with tagging and resource management


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Fix bucket name references in tagging logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Updated bucket name reference in <code>list_of_buckets_to_be_tagged</code> to use <br><code>bucket.name</code> instead of <code>local.generated_bucket_names[bucket.name]</code><br> <li> Modified <code>parent</code> attribute in <code>google_tags_location_tag_binding</code> resource <br>to use <code>local.generated_bucket_names[each.value.bucket_name]</code><br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-application-bucket-creation-helper/pull/21/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

