### PR TITLE
feat: upgrade renovate configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TERRAFORM_DOCS_IMAGE_TAG ?= 0.18.0
+
 .PHONY: lint tfscan generate-docs
 
 lint:
@@ -10,7 +12,7 @@ generate-docs: lint
 	docker run --rm -u $$(id -u) \
 		--volume "$(PWD):/terraform-docs" \
 		-w /terraform-docs \
-		quay.io/terraform-docs/terraform-docs:0.16.0 markdown table --config .terraform-docs.yml --output-file README.md --output-mode inject .
+		quay.io/terraform-docs/terraform-docs:$(TERRAFORM_DOCS_IMAGE_TAG) markdown table --config .terraform-docs.yml --output-file README.md --output-mode inject .
 
 # Renovate configuration test
 renovate-test:

--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sparkfabrik/renovatebot-default-configuration"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["Makefile"],
-      "matchStrings": ["TERRAFORM_DOCS_VERSION \\?= (?<currentValue>.*?)\n"],
-      "depNameTemplate": "terraform_docs_makefile",
-      "versioningTemplate": "semver-coerced",
-      "datasourceTemplate": "custom.terraform_docs_makefile"
-    }
-  ],
-  "customDatasources": {
-    "terraform_docs_makefile": {
-      "defaultRegistryUrlTemplate": "https://quay.io/api/v1/repository/terraform-docs/terraform-docs/tag/",
-      "transformTemplates": [
-        "{ \"releases\": $map($.tags, function($v) { { \"version\": $v.name } }) }"
-      ]
-    }
-  }
+  "extends": [
+    "github>sparkfabrik/renovatebot-default-configuration",
+    "github>sparkfabrik/renovatebot-default-configuration//custom/terraform_docs"
+  ]
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified Renovate configuration by removing inline custom configurations
- Added reference to external terraform_docs configuration from sparkfabrik repository
- Removed custom regex manager for Makefile terraform-docs version tracking
- Removed custom datasource configuration for quay.io terraform-docs repository
- Configuration now extends from two sources:
  * Base configuration from sparkfabrik/renovatebot-default-configuration
  * Terraform-docs specific configuration from sparkfabrik/renovatebot-default-configuration/custom/terraform_docs



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Streamline Renovate configuration with external terraform_docs</code></dd></summary>
<hr>

renovate.json

<li>Simplified configuration by removing custom managers and datasources<br> <li> Added reference to external terraform_docs configuration<br> <li> Maintained base configuration from sparkfabrik default<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-application-bucket-creation-helper/pull/24/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+4/-19</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information